### PR TITLE
Restore previous /nostr redirect under /NostrFAQ instead

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -56,7 +56,7 @@ module.exports = {
         permanent: true,
       },
       {
-        source: "/nostr",
+        source: "/NostrFAQ",
         destination: "https://uselessshit.co/resources/nostr/",
         permanent: true,
       },


### PR DESCRIPTION
There was a conflict for my new "/nostr" pubkey to Amethyst/Damus redirect. So restoring the oldie to have FAQ handy